### PR TITLE
Fix default user to pulseuser

### DIFF
--- a/pulse_xmpp_agent/lib/utils.py
+++ b/pulse_xmpp_agent/lib/utils.py
@@ -1491,7 +1491,7 @@ def check_exist_ip_port(name_domaine_or_ip, port):
 
 
 def install_or_uninstall_keypub_authorized_keys(
-        install=True, keypub=None, user="pulse"):
+        install=True, keypub=None, user="pulseuser"):
     """
         This function installs or uninstall the public key in the authorized_keys file for the "user"/
 
@@ -1593,6 +1593,7 @@ def get_keypub_ssh(name="id_rsa.pub", user="root"):
     return keypub
 
 
+if sys.platform.startswith('win'):
 def get_sid_user(name):
     """
         for windows only
@@ -1604,7 +1605,6 @@ def get_sid_user(name):
         return dev.SID
 
 
-if sys.platform.startswith('win'):
     def set_reg(name, value, subkey, key=wr.HKEY_LOCAL_MACHINE,
                 type=wr.REG_SZ):
         try:


### PR DESCRIPTION
in  the install_or_uninstall_keypub_authorized_keys function, set the user to pulseuser by default instead of pulse.

The get_sid_user function is windows only. Then protect it with if sys.platform.startswith('win') too.