### PR TITLE
(utils) Fix finding the hosts

### DIFF
--- a/pulse_xmpp_agent/connectionagent.py
+++ b/pulse_xmpp_agent/connectionagent.py
@@ -33,6 +33,7 @@ import base64
 import time
 import json
 import re
+import socket
 from sleekxmpp import jid
 import traceback
 from sleekxmpp.exceptions import IqError, IqTimeout


### PR DESCRIPTION
In some circunstances, we failed to define the dns of the main or
relayserver.

Now we try the Dns Resolution and if we fail we add it directly in the
hosts file of the client.

This way we do not rely on the DNS resolution and do not fail anymore.