### PR TITLE
(utils) Fix finding the hosts

### DIFF
--- a/pulse_xmpp_agent/connectionagent.py
+++ b/pulse_xmpp_agent/connectionagent.py
@@ -33,6 +33,7 @@ import base64
 import time
 import json
 import re
+import socket
 from sleekxmpp import jid
 import traceback
 from sleekxmpp.exceptions import IqError, IqTimeout

--- a/pulse_xmpp_agent/lib/utils.py
+++ b/pulse_xmpp_agent/lib/utils.py
@@ -1374,25 +1374,82 @@ class protodef:
 def protoandport():
     return protodef.protoandport()
 
+def get_path_file_hosts():
+    """
+        Find the hosts file depending of the OS.
+
+        ex:
+            For linux and darwin: /etc/hosts
+            For windows: C:\windows\system32\drivers\etc\hosts
+    """
+    hostsfile = ""
+    if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
+       hostsfile = "/etc/hosts"
+    elif sys.platform.startswith('win'):
+        hostsfile = "C:\\windows\\system32\\drivers\\etc\\hosts"
+    return hostsfile
+
+def get_hosts_exists():
+    """
+        Checks of the hosts file exists.
+
+        Returns:
+            True if it exists
+            False if it does not exists
+    """
+    if os.path.exists(get_path_file_hosts()):
+        return True
+    return False
+
+def configure_host_file(name_domaine_or_ip, ip):
+    """
+        Configure the hosts file to add the ip and dns inside.
+    """
+    inputFile = open(get_path_file_hosts(), 'r')
+    lines = inputFile.readlines()
+    inputFile.close()
+    result = []
+
+    for line in lines:
+        if name_domaine_or_ip in line:
+            continue
+        else:
+            result.append(line)
+
+    result.append("%s\t%s" % (ip, name_domaine_or_ip))
+    file_put_contents(get_path_file_hosts(), "" . join(result))
+
 def ipfromdns(name_domaine_or_ip):
-    """ This function converts a dns to ipv4
+    """
+        This function converts a dns to ipv4
+
         If not find return ""
-        function tester on OS:
+
+        If the DNS Resolution fails it updates the hosts file directly,
+        otherwise it uses the DNS Resolution.
+
+        function tested on OS:
         MAcOs, linux (debian, redhat, ubuntu), windows
         eg : print ipfromdns("sfr.fr")
         80.125.163.172
     """
-    if name_domaine_or_ip != "" and name_domaine_or_ip != None:
+    ip = None
+    logger.error("IP returned by the Dns Utils %s " name_domaine_or_ip)
+    if name_domaine_or_ip:
         if is_valid_ipv4(name_domaine_or_ip):
             return name_domaine_or_ip
+
         try:
-            return socket.gethostbyname(name_domaine_or_ip)
+            ip = socket.gethostbyname(name_domaine_or_ip)
+            if ip :
+                configure_host_file(name_domaine_or_ip, ip)
+                return ip
         except socket.gaierror:
             return ""
         except Exception:
+            logger.error("%s" % (traceback.format_exc()))
             return ""
     return ""
-
 
 def data_struct_message(action, data={}, ret=0, base64=False, sessionid=None):
     if sessionid == None or sessionid == "" or not isinstance(sessionid, basestring):


### PR DESCRIPTION
In some circunstances, we failed to define the dns of the main or
relayserver.

Now we try the Dns Resolution and if we fail we add it directly in the
hosts file of the client.

This way we do not rely on the DNS resolution and do not fail anymore.