### PR TITLE
[FIX CDN] Fix creation hash suffix error

### DIFF
--- a/pulse_xmpp_master_substitute/pluginsmastersubstitute/plugin_loaddeployment.py
+++ b/pulse_xmpp_master_substitute/pluginsmastersubstitute/plugin_loaddeployment.py
@@ -837,7 +837,7 @@ def generate_hash(path, package_id, hash_type, packages, keyAES32):
                 file_block = _file.read(BLOCK_SIZE) # Read the next block from the file
 
         try:
-            with open("%s.hash" % (os.path.join(dest, file_package)) + ".hash", 'wb') as _file:
+            with open((os.path.join(dest, file_package)) + ".hash", 'wb') as _file:
                 _file.write(file_hash.hexdigest())
         except:
             logging.error("Error writing the hash for %s" % file_package)


### PR DESCRIPTION
When we create hash for every file in package in case of CDN deployment, new file be created with 2 suffix ".hash" Example : conf.json.hash.hash
Now, create file with only one ".hash"
Example : conf.json.hash
If "filename.hash" already exist, replace it.