### PR TITLE
[pkgs] Create plugin to manage package synchronisation notifications in place of master

### DIFF
--- a/pulse_xmpp_master_substitute/pluginsmastersubstitute/plugin_notifysyncthing.py
+++ b/pulse_xmpp_master_substitute/pluginsmastersubstitute/plugin_notifysyncthing.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; -*-
+#
+# (c) 2016-2023 siveo, http://www.siveo.net
+#
+# This file is part of medulla, http://www.siveo.net
+#
+# medulla is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# medulla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with medulla; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+# file /pluginsmastersubstitute/plugin_notifysyncthing.py
+
+import base64
+import json
+import os
+import lib.utils
+import pprint
+import logging
+from lib.plugins.pkgs import PkgsDatabase
+
+logger = logging.getLogger()
+
+plugin = { "VERSION" : "1.0", "NAME" : "notifysyncthing", "TYPE" : "substitute" }
+
+def action( objectxmpp, action, sessionid, data, msg, dataerreur):
+    logger.debug("=====================================================")
+    logger.debug(plugin)
+    logger.debug("=====================================================")
+    print json.dumps(data, indent = 4)
+    if 'suppdir' in data or 'adddir' in data:
+        logger.debug("removing package %s %s %s"%( data['packageid'], 'create', str(msg['from'])))
+        PkgsDatabase().pkgs_unregister_synchro_package( data['packageid'],
+                                                      None,
+                                                      str(msg['from']))
+    elif 'MotifyFile' in data:
+        logger.debug("removing package %s %s %s"%( data['packageid'], 'chang', str(msg['from'])))
+        PkgsDatabase().pkgs_unregister_synchro_package( data['packageid'],
+                                                      'chang',
+                                                      str(msg['from']))
+


### PR DESCRIPTION
… fonctionalité et l'attribuer a 1 substitut)

l'agent dans la fonction handle_client_connection appelle le plugin notifysyncthing sur master pour utiliser se plugin il faut remplacer l'appel a master ("function  send_message_to_master") dans fonction handle_client_connection de l'agent et envoyer au substitut choisie qui doit implemente pkgs ans sa configuration. (activate_plugin = pkgs)

(cherry picked from commit 99a7f02e0ed60ff50bfe2acc73528bf2934fcf8d)